### PR TITLE
fixed scroll

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -10,7 +10,7 @@
 </ion-header>
 
 <!-- Check to make sure the isHidden property is in the right place -->
-<ion-content class="ion-no-padding" scroll="false">
+<ion-content class="ion-no-padding" [scrollY]="hideEnrolOptions">
   <ion-refresher
     *ngIf="hideEnrolOptions"
     slot="fixed"


### PR DESCRIPTION
Small fix: Scrolling on home page (in logged out view) disabled. (home-scroll-fix -> new-designs)

In more detail:
When a user is not enrolled in a study, and therefore sees the "normal" home page from the "logged out" view, scrolling should be disabled. But the code didn't disable scrolling properly, so this should fix it.